### PR TITLE
fix: Fix Dockerfile build issue with swagger dist files

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,10 +1,15 @@
 FROM golang:1.24.2-alpine3.20 AS builder
 
 WORKDIR /app
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy all source code including swagger dist files
 COPY . .
 
-COPY go.mod go.sum ./
-RUN go mod tidy
+# Build the application
 RUN go build -o main ./main.go
 
 FROM alpine:3.14


### PR DESCRIPTION
- Reorder COPY commands to ensure proper build context
- Copy go.mod/go.sum first for better Docker layer caching
- Copy all source files including swagger/dist/* before build
- Resolves 'pattern dist/*: no matching files found' error